### PR TITLE
Replace 'ThingFilterUI.DoThingFilterConfigWindow' detour with transpiler

### DIFF
--- a/Source/Detours.cs
+++ b/Source/Detours.cs
@@ -143,9 +143,10 @@ namespace ZhentarTweaks
 
 			foreach (var type in toTypes)
 			{
-				foreach (var constructor in type.GetMembers(UniversalBindingFlags).OfType<MethodBase>().Where(c => c.HasAttribute<TAttribute>()))
-				{
-					constructor.TryGetAttribute<TAttribute>(out var detour);
+				foreach (var constructor in type.GetMembers(UniversalBindingFlags).OfType<MethodBase>().Where(c => c.HasAttribute<TAttribute>())) {
+				    TAttribute detour;
+
+                    constructor.TryGetAttribute<TAttribute>(out detour);
 
 					var targetConstructor = detour.TargetClass.GetConstructors(UniversalBindingFlags)
 							.FirstOrDefault(ctor => (ctor.GetParameters().Select(checkParameter => checkParameter.ParameterType)
@@ -190,9 +191,10 @@ namespace ZhentarTweaks
 			var destinationMethods = destinationType
 				.GetMethods(UniversalBindingFlags)
 				.Where(destinationMethod => destinationMethod.HasAttribute<TAttribute>());
-			foreach (var destinationMethod in destinationMethods)
-			{
-				if (destinationMethod.TryGetAttribute<TAttribute>(out var attribute))
+			foreach (var destinationMethod in destinationMethods) {
+			    TAttribute attribute;
+
+                if (destinationMethod.TryGetAttribute<TAttribute>(out attribute))
 				{
 					var memberClass = GetDetourTargetClass(destinationMethod, attribute);
 					if (memberClass == null)
@@ -221,9 +223,10 @@ namespace ZhentarTweaks
 			var destinationProperties = destinationType
 				.GetProperties(UniversalBindingFlags)
 				.Where(destinationProperty => destinationProperty.HasAttribute<TAttribute>());
-			foreach (var destinationProperty in destinationProperties)
-			{
-				if (destinationProperty.TryGetAttribute<TAttribute>(out var attribute))
+			foreach (var destinationProperty in destinationProperties) {
+			    TAttribute attribute;
+
+                if (destinationProperty.TryGetAttribute<TAttribute>(out attribute))
 				{
 					var memberClass = GetDetourTargetClass(destinationProperty, attribute);
 					if (memberClass == null)


### PR DESCRIPTION
Seems you're still using a hard detour for ThingFilterUI.DoThingFilterConfigWindow.

I've modified the code to use a minimal transpiled version that preserves your logic, but also allows other mods to inject (and keep!) their logic in there.

From my understanding all you're *changing* here is adding a call to `DrawMarketValueFilterConfig`. That can easily be done without a detour.

For a version happily interacting with StorageSearch see 

![image](https://user-images.githubusercontent.com/324067/29578544-e708e180-876f-11e7-8e88-78b8b5926404.png)

---

I also had to change three small lines to allow compilation with c#6, since I don't have a version of vs2017 installed currently - but those changes are non essential to the actual transpiler.